### PR TITLE
Increase pwm

### DIFF
--- a/variants/arduino_due_x/variant.h
+++ b/variants/arduino_due_x/variant.h
@@ -223,7 +223,7 @@ static const uint8_t CAN1TX = 89;
  */
 #define PWM_INTERFACE		PWM
 #define PWM_INTERFACE_ID	ID_PWM
-#define PWM_FREQUENCY		20000
+#define PWM_FREQUENCY		16000
 #define PWM_MAX_DUTY_CYCLE	255
 #define PWM_MIN_DUTY_CYCLE	0
 #define PWM_RESOLUTION		8

--- a/variants/arduino_due_x/variant.h
+++ b/variants/arduino_due_x/variant.h
@@ -223,7 +223,7 @@ static const uint8_t CAN1TX = 89;
  */
 #define PWM_INTERFACE		PWM
 #define PWM_INTERFACE_ID	ID_PWM
-#define PWM_FREQUENCY		1000
+#define PWM_FREQUENCY		20000
 #define PWM_MAX_DUTY_CYCLE	255
 #define PWM_MIN_DUTY_CYCLE	0
 #define PWM_RESOLUTION		8
@@ -233,7 +233,7 @@ static const uint8_t CAN1TX = 89;
  */
 #define TC_INTERFACE        TC0
 #define TC_INTERFACE_ID     ID_TC0
-#define TC_FREQUENCY        1000
+#define TC_FREQUENCY        PWM_FREQUENCY
 #define TC_MAX_DUTY_CYCLE   255
 #define TC_MIN_DUTY_CYCLE   0
 #define TC_RESOLUTION		8


### PR DESCRIPTION
This 2 line PR changes the Arduino Timer Capture time basis to 16 kHz, up from 1 kHz.  This branch change should only be used with firmware that limits brake drive commands to pulsewidths above 800ns.  See https://github.com/proteusmotion/proteus-serial-interface/tree/increasePWM